### PR TITLE
feature/prepend-protocols

### DIFF
--- a/src/variables/InlinVariable.php
+++ b/src/variables/InlinVariable.php
@@ -29,9 +29,12 @@ class InlinVariable
         $filePath = $this->_removeDoubleSlashes($webroot.'/'.$fileName);
 
         if ($remote) {
-            $content = @file_get_contents($fileName);
+            if (strpos($fileName, '//') === 0) {
+                $protocol = Craft::$app->request->isSecureConnection ? 'https:' : 'http:';
+                $fileName = $protocol.$fileName;
+            }
 
-            return $content;
+            return @file_get_contents($fileName);
         }
 
         if ($fileName !== '' && file_exists($filePath)) {

--- a/src/variables/InlinVariable.php
+++ b/src/variables/InlinVariable.php
@@ -39,8 +39,6 @@ class InlinVariable
 
             return $content;
         }
-
-        return '';
     }
 
     /**

--- a/src/variables/InlinVariable.php
+++ b/src/variables/InlinVariable.php
@@ -10,6 +10,7 @@
 
 namespace aelvan\inlin\variables;
 
+use Craft;
 use aelvan\inlin\Inlin;
 
 class InlinVariable
@@ -24,8 +25,8 @@ class InlinVariable
      */
     public function er($fileName, $remote = false): string
     {
-        $documentRoot = Inlin::getInstance()->getSettings()->publicRoot ?? $_SERVER['DOCUMENT_ROOT'];
-        $filePath = $this->_removeDoubleSlashes($documentRoot.'/'.$fileName);
+        $webroot = Craft::getAlias('@webroot');
+        $filePath = $this->_removeDoubleSlashes($webroot.'/'.$fileName);
 
         if ($remote) {
             $content = @file_get_contents($fileName);


### PR DESCRIPTION
Fixes an issue where volumes configured without a protocol would not load.

> `file_get_contents` cannot load URLs that are missing the protocol. For example, `//example.com/logo.svg`.